### PR TITLE
Remove postcss-cli dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* Remove postcss-cli dependency
+* Remove postcss-cli dependency and upgrade other dependencies.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Remove postcss-cli dependency
+
 ## 1.0.0
 
 * Initial release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-src",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A PostCSS polyfill for the CSS src() function.",
   "keywords": [
     "postcss",
@@ -45,7 +45,6 @@
     "node": ">=8.3.0"
   },
   "dependencies": {
-    "postcss-cli": "^10.0.0",
     "postcss-value-parser": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "@babel/preset-env": "^7.7.7",
     "@types/jest": "^27.5.2",
     "@types/node": "^12.12.7",
-    "babel-jest": "^27.5.1",
-    "gts": "^4.0.0",
-    "jest": "^27.0.4",
+    "babel-jest": "^29.5.0",
+    "gts": "^3.1.1",
+    "jest": "^29.5.0",
     "jest-cli": "^27.0.4",
     "postcss": "^8.2.6",
-    "ts-jest": "^27.0.3",
-    "typescript": "^3.8.0"
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.1.3"
   },
   "peerDependencies": {
     "postcss": "^8.2.6"

--- a/package.json
+++ b/package.json
@@ -25,18 +25,19 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/google/postcss-src",
   "devDependencies": {
-    "@babel/cli": "^7.6.0",
-    "@babel/core": "^7.7.7",
-    "@babel/preset-env": "^7.7.7",
-    "@types/jest": "^27.5.2",
-    "@types/node": "^12.12.7",
+    "@babel/cli": "^7.22.5",
+    "@babel/core": "^7.22.5",
+    "@babel/preset-env": "^7.22.5",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.3.1",
     "babel-jest": "^29.5.0",
     "gts": "^3.1.1",
     "jest": "^29.5.0",
-    "jest-cli": "^27.0.4",
+    "jest-cli": "^29.5.0",
     "postcss": "^8.2.6",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "jest-environment-jsdom": "^29.5.0"
   },
   "peerDependencies": {
     "postcss": "^8.2.6"


### PR DESCRIPTION
Dependency on postcss-cli is no longer necessary.